### PR TITLE
compress downsample output

### DIFF
--- a/modules/local/rna_subsample_region.nf
+++ b/modules/local/rna_subsample_region.nf
@@ -27,7 +27,7 @@ process RNA_SUBSAMPLE_REGION {
 
     """
     samtools view -@ $task.cpus -b -U non_select.bam -L ${subsample_bed} ${bam} | samtools view -s ${seed_frac} -@ $task.cpus -b -o select.bam
-    samtools merge -u non_select.bam select.bam -o ${prefix}_subsamp.bam
+    samtools merge --threads $task.cpus non_select.bam select.bam -o ${prefix}_subsamp.bam
     samtools index ${prefix}_subsamp.bam
 
     cat <<-END_VERSIONS > versions.yml


### PR DESCRIPTION
The `-u` option will create an uncompressed bam which is rather large. In some iterations of this script we bundled the hemoglobin downsampling with the general read downsampling and streamed the output. In this version it would be better to compress the output file. 


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/tomte/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
