### PR TITLE
Fix channels in the GATK subworkflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Release of genomic-medicine-sweden/tomte, created with the [nf-core](https://nf-
 - Shortened name of DROP output files [#79](https://github.com/genomic-medicine-sweden/tomte/pull/79)
 - Merging of vcfs has been moved to after bootstrapAnn [#81](https://github.com/genomic-medicine-sweden/tomte/pull/81)
 - Substituted bgzip and tabix modules by bgzip_tabix module [#85](https://github.com/genomic-medicine-sweden/tomte/pull/85)
+- Updated module input channels in the GATK variant calling subworkflow [#89](https://github.com/genomic-medicine-sweden/tomte/pull/85)
 
 ### `Dependencies`
 

--- a/subworkflows/local/call_variants_gatk.nf
+++ b/subworkflows/local/call_variants_gatk.nf
@@ -35,7 +35,7 @@ workflow CALL_VARIANTS_GATK {
 
         ch_split_bam_bai = GATK4_SPLITNCIGARREADS.out.bam.join(SAMTOOLS_INDEX.out.bai)
 
-	    GATK4_HAPLOTYPECALLER(
+        GATK4_HAPLOTYPECALLER(
             ch_split_bam_bai.map{ meta, bam, bai -> [meta, bam, bai, [], []] },
             ch_fasta.map{ fasta -> [[:], fasta] },
             ch_fai.map{ fai -> [[:], fai] },


### PR DESCRIPTION
Some of the nf-core GATK module updates may have changed their input channels, while the subworkflow hasn't been updated.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/tomte/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
