### PR TITLE
Scatter-gather parallelisation of GATK4 ASEReadCounter

### DIFF
--- a/.github/workflows/linting_comment.yml
+++ b/.github/workflows/linting_comment.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "pr_number=$(cat linting-logs/PR_number.txt)" >> $GITHUB_OUTPUT
 
       - name: Post PR comment
-        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.pr_number.outputs.pr_number }}

--- a/.github/workflows/linting_comment.yml
+++ b/.github/workflows/linting_comment.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "pr_number=$(cat linting-logs/PR_number.txt)" >> $GITHUB_OUTPUT
 
       - name: Post PR comment
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.pr_number.outputs.pr_number }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ testing/
 testing*
 *.pyc
 null/
+.nf-test/
+.nf-test.log
+#*#

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,4 @@ testing/
 testing*
 *.pyc
 null/
-.nf-test/
-.nf-test.log
-#*#
+.nf-test*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- Scatter-gather parallelisation of GATK4 ASEReadCounter: each sample is now processed per chromosome in parallel and results merged, reducing runtime and peak memory usage.
+- New local modules: `split_fai_intervals`, `split_bed_by_chrom`, `merge_ase_csvs`.
+
 ### `Changed`
 
 - Updated version to 4.3.0dev [#288](https://github.com/genomic-medicine-sweden/tomte/pull/288)
@@ -19,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Old parameter | New parameter |
 | ------------- | ------------- |
+|               | ase_intervals |
+|               | ase_max_depth |
 
 > [!NOTE]
 > Parameter has been updated if both old and new parameter information is present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- Scatter-gather parallelisation of GATK4 ASEReadCounter: each sample is now processed per chromosome in parallel and results merged, reducing runtime and peak memory usage.
+- Scatter-gather parallelisation of GATK4 ASEReadCounter: each sample is now processed per chromosome in parallel and results merged, reducing runtime and peak memory usage. [#293](https://github.com/genomic-medicine-sweden/tomte/pull/293)
 - New local modules: `split_fai_intervals`, `split_bed_by_chrom`, `merge_ase_csvs`.
 
 ### `Changed`

--- a/conf/modules/allele_specific_calling.config
+++ b/conf/modules/allele_specific_calling.config
@@ -34,6 +34,8 @@ process {
     withName: '.*ALLELE_SPECIFIC_CALLING:GATK4_ASEREADCOUNTER' {
         // Unique prefix per sample+interval to avoid filename collisions during scatter
         ext.prefix = { "${meta.id}_${meta.interval}" }
+        // Cap read depth per locus to prevent OOM on high-coverage regions (e.g. highly expressed genes)
+        ext.args = { "--max-depth-per-sample ${params.ase_max_depth}" }
     }
 
     withName: '.*ALLELE_SPECIFIC_CALLING:MERGE_ASE_CSVS' {

--- a/conf/modules/allele_specific_calling.config
+++ b/conf/modules/allele_specific_calling.config
@@ -31,6 +31,15 @@ process {
         ext.args = { '--genotype het --max-alleles 2 --min-alleles 2 --types snps --output-type z --write-index=tbi' }
     }
 
+    withName: '.*ALLELE_SPECIFIC_CALLING:GATK4_ASEREADCOUNTER' {
+        // Unique prefix per sample+interval to avoid filename collisions during scatter
+        ext.prefix = { "${meta.id}_${meta.interval}" }
+    }
+
+    withName: '.*ALLELE_SPECIFIC_CALLING:MERGE_ASE_CSVS' {
+        ext.prefix = { "${meta.id}" }
+    }
+
     withName: '.*ALLELE_SPECIFIC_CALLING:BCFTOOLS_MERGE' {
         ext.args = '--output-type z'
         ext.prefix = { "${meta.id}" }

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -72,6 +72,8 @@ Options related to variant calling
 |-----------|-----------|-----------|-----------|-----------|-----------|
 | `variant_caller` | Program to use for variant calling (accepted: `bcftools`\|`gatk`) <details><summary>Help</summary><small>The pipeline can use either bcftools mpileup/call or GATK haplotypecaller for calling SNV/INDELS on the RNAseq data.</small></details>| `string` | bcftools |  |  |
 | `bcftools_caller_mode` | Run bcftools call in either consensus or multiallelic mode (accepted: `consensus`\|`multiallelic`) <details><summary>Help</summary><small>Bcftools call can eitherbe run in multiallelic mode or in consensus mode. In consensus mode a p-value threshold of 0.01 is applied.</small></details>| `string` | multiallelic |  |  |
+| `ase_intervals` | BED file of regions to restrict GATK4 ASEReadCounter to (e.g. exons). When provided, the BED is split by chromosome and each job runs on one chromosome's regions in parallel. | `string` |  |  |  |
+| `ase_max_depth` | Maximum read depth per locus for GATK4 ASEReadCounter (--max-depth-per-sample). Lower values reduce memory usage on high-coverage regions. | `integer` | 1000 |  |  |
 | `skip_variant_calling` | Skip variant calling for all samples. | `boolean` | False |  |  |
 | `skip_build_tracks` | Skip building splice junction tracks for IGV. | `boolean` | False |  |  |
 | `skip_stringtie` | Skip analysis with StringTie | `boolean` | False |  |  |

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -73,7 +73,7 @@ Options related to variant calling
 | `variant_caller` | Program to use for variant calling (accepted: `bcftools`\|`gatk`) <details><summary>Help</summary><small>The pipeline can use either bcftools mpileup/call or GATK haplotypecaller for calling SNV/INDELS on the RNAseq data.</small></details>| `string` | bcftools |  |  |
 | `bcftools_caller_mode` | Run bcftools call in either consensus or multiallelic mode (accepted: `consensus`\|`multiallelic`) <details><summary>Help</summary><small>Bcftools call can eitherbe run in multiallelic mode or in consensus mode. In consensus mode a p-value threshold of 0.01 is applied.</small></details>| `string` | multiallelic |  |  |
 | `ase_intervals` | BED file of regions to restrict GATK4 ASEReadCounter to (e.g. exons). When provided, the BED is split by chromosome and each job runs on one chromosome's regions in parallel. | `string` |  |  |  |
-| `ase_max_depth` | Maximum read depth per locus for GATK4 ASEReadCounter (--max-depth-per-sample). Lower values reduce memory usage on high-coverage regions. | `integer` | 1000 |  |  |
+| `ase_max_depth` | Maximum read depth per locus for GATK4 ASEReadCounter (--max-depth-per-sample). Lower values reduce memory usage on high-coverage regions. Set to 0 to disable the cap (GATK default). | `integer` | 1000 |  |  |
 | `skip_variant_calling` | Skip variant calling for all samples. | `boolean` | False |  |  |
 | `skip_build_tracks` | Skip building splice junction tracks for IGV. | `boolean` | False |  |  |
 | `skip_stringtie` | Skip analysis with StringTie | `boolean` | False |  |  |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -213,10 +213,14 @@ The mandatory and optional parameters for each category are tabulated below.
 |           | variant_caller<sup>1</sup>       |
 |           | bcftools_caller_mode<sup>2</sup> |
 |           | skip_variant_calling<sup>3</sup> |
+|           | ase_intervals<sup>4</sup>        |
+|           | ase_max_depth<sup>5</sup>        |
 
 <sup>1</sup> If it is not provided by the user, the default value is bcftools<br />
 <sup>2</sup> If it is not provided by the user, the default value is multiallelic<br />
-<sup>3</sup> If it is not provided by the user, the default value is false
+<sup>3</sup> If it is not provided by the user, the default value is false<br />
+<sup>4</sup> Optional BED file with regions (e.g. exons) to restrict ASEReadCounter to. If not provided, ASEReadCounter runs per whole chromosome. Providing an exon BED file reduces runtime and memory usage significantly.<br />
+<sup>5</sup> If it is not provided by the user, the default value is 1000. Sets the maximum read depth per sample for GATK4 ASEReadCounter (`--max-depth-per-sample`).
 
 #### 5. SNV annotation (ensembl VEP)
 

--- a/modules/local/merge_ase_csvs/main.nf
+++ b/modules/local/merge_ase_csvs/main.nf
@@ -25,7 +25,7 @@ process MERGE_ASE_CSVS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        awk: \$(awk --version 2>&1 | awk 'NR==1{print \$3}' | tr -d ',')
+        awk: \$( { awk --version; awk -Wversion; } 2>&1 | grep -oE '[0-9]+[.][0-9]+[.][0-9]+' | head -1 )
     END_VERSIONS
     """
 

--- a/modules/local/merge_ase_csvs/main.nf
+++ b/modules/local/merge_ase_csvs/main.nf
@@ -1,0 +1,42 @@
+process MERGE_ASE_CSVS {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "conda-forge::gawk=5.3.0"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ubuntu:22.04' :
+        'nf-core/ubuntu:22.04' }"
+
+    input:
+    tuple val(meta), path(csvs)
+
+    output:
+    tuple val(meta), path("*_ase.csv"), emit: csv
+    path "versions.yml",                emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    # Merge CSVs: keep header from first file, skip header in subsequent files
+    awk 'FNR==1 && NR>1 {next} {print}' ${csvs} > ${prefix}_ase.csv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        awk: \$(awk --version 2>&1 | head -1 | sed 's/[^0-9.]//g; s/^\\.//; s/\\.$//; s/\\.\\.*/./g')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}_ase.csv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        awk: 5.3.0
+    END_VERSIONS
+    """
+}

--- a/modules/local/merge_ase_csvs/main.nf
+++ b/modules/local/merge_ase_csvs/main.nf
@@ -25,7 +25,7 @@ process MERGE_ASE_CSVS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        awk: \$(awk --version 2>&1 | head -1 | sed 's/[^0-9.]//g; s/^\\.//; s/\\.$//; s/\\.\\.*/./g')
+        awk: \$(awk --version 2>&1 | awk 'NR==1{print \$3}' | tr -d ',')
     END_VERSIONS
     """
 

--- a/modules/local/merge_ase_csvs/tests/csv/test_chr1_ase.csv
+++ b/modules/local/merge_ase_csvs/tests/csv/test_chr1_ase.csv
@@ -1,0 +1,3 @@
+contig	position	variantID	refAllele	altAllele	refCount	altCount	totalCount	lowMAPQDepth	lowBaseQDepth	rawDepth	otherBases	improperPairs
+1	100000	.	A	T	12	8	20	0	0	20	0	0
+1	200000	.	G	C	15	10	25	0	0	25	0	0

--- a/modules/local/merge_ase_csvs/tests/csv/test_chr2_ase.csv
+++ b/modules/local/merge_ase_csvs/tests/csv/test_chr2_ase.csv
@@ -1,0 +1,3 @@
+contig	position	variantID	refAllele	altAllele	refCount	altCount	totalCount	lowMAPQDepth	lowBaseQDepth	rawDepth	otherBases	improperPairs
+2	150000	.	C	A	20	5	25	0	0	25	0	0
+2	300000	.	T	G	8	12	20	0	0	20	0	0

--- a/modules/local/merge_ase_csvs/tests/main.nf.test
+++ b/modules/local/merge_ase_csvs/tests/main.nf.test
@@ -1,0 +1,33 @@
+nextflow_process {
+
+    name "Test Process MERGE_ASE_CSVS"
+    script "../main.nf"
+    process "MERGE_ASE_CSVS"
+    tag "modules_local"
+    tag "modules"
+    tag "merge_ase_csvs"
+
+    test("Should run without failures") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ],
+                    [
+                        file("${projectDir}/modules/local/merge_ase_csvs/tests/csv/test_chr1_ase.csv", checkIfExists: true),
+                        file("${projectDir}/modules/local/merge_ase_csvs/tests/csv/test_chr2_ase.csv", checkIfExists: true)
+                    ]
+                ])
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(process.out).match()
+        }
+
+    }
+
+}

--- a/modules/local/merge_ase_csvs/tests/main.nf.test.snap
+++ b/modules/local/merge_ase_csvs/tests/main.nf.test.snap
@@ -1,0 +1,35 @@
+{
+    "Should run without failures": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_ase.csv:md5,75e3e4c43fd7c0fc34aeda9c3a72306a"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,10df6aa740762f79d02fe029a4e47520"
+                ],
+                "csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_ase.csv:md5,75e3e4c43fd7c0fc34aeda9c3a72306a"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,10df6aa740762f79d02fe029a4e47520"
+                ]
+            }
+        ],
+        "timestamp": "2026-03-22T10:04:16.619302046",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.5"
+        }
+    }
+}

--- a/modules/local/split_bed_by_chrom/main.nf
+++ b/modules/local/split_bed_by_chrom/main.nf
@@ -20,11 +20,11 @@ process SPLIT_BED_BY_CHROM {
     script:
     """
     # Split BED file into per-chromosome files, keeping only standard chromosomes
-    awk '\$1 ~ /^(chr[0-9]+|chr[XYM]|chrMT|[1-9][0-9]?|X|Y|MT?)$/ {print > \$1".bed"}' ${bed}
+    awk '\$1 ~ "^(chr[0-9]+|chr[XYM]|chrMT|[1-9][0-9]?|X|Y|MT?)\$" {print > \$1".bed"}' ${bed}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        awk: \$(awk --version 2>&1 | head -1 | sed 's/[^0-9.]//g; s/^\\.//; s/\\.$//; s/\\.\\.*/./g')
+        awk: \$(awk --version 2>&1 | awk 'NR==1{print \$3}' | tr -d ',')
     END_VERSIONS
     """
 

--- a/modules/local/split_bed_by_chrom/main.nf
+++ b/modules/local/split_bed_by_chrom/main.nf
@@ -1,0 +1,40 @@
+process SPLIT_BED_BY_CHROM {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "conda-forge::gawk=5.3.0"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ubuntu:22.04' :
+        'nf-core/ubuntu:22.04' }"
+
+    input:
+    tuple val(meta), path(bed)
+
+    output:
+    path "*.bed",        emit: intervals
+    path "versions.yml", emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    """
+    # Split BED file into per-chromosome files, keeping only standard chromosomes
+    awk '\$1 ~ /^(chr[0-9]+|chr[XYM]|chrMT|[1-9][0-9]?|X|Y|MT?)$/ {print > \$1".bed"}' ${bed}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        awk: \$(awk --version 2>&1 | head -1 | sed 's/[^0-9.]//g; s/^\\.//; s/\\.$//; s/\\.\\.*/./g')
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch chr1.bed
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        awk: 5.3.0
+    END_VERSIONS
+    """
+}

--- a/modules/local/split_bed_by_chrom/tests/main.nf.test
+++ b/modules/local/split_bed_by_chrom/tests/main.nf.test
@@ -1,0 +1,33 @@
+nextflow_process {
+
+    name "Test Process SPLIT_BED_BY_CHROM"
+    script "../main.nf"
+    process "SPLIT_BED_BY_CHROM"
+    tag "modules_local"
+    tag "modules"
+    tag "split_bed_by_chrom"
+
+    test("Should run without failures") {
+
+        when {
+            params {
+                modules_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(process.out).match()
+        }
+
+    }
+
+}

--- a/modules/local/split_bed_by_chrom/tests/main.nf.test.snap
+++ b/modules/local/split_bed_by_chrom/tests/main.nf.test.snap
@@ -6,17 +6,17 @@
                     "chr22.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
                 ],
                 "1": [
-                    "versions.yml:md5,4b4468e7d489cd525c0a04c2b6108f7d"
+                    "versions.yml:md5,cf114805fa4ead7ebdb7f875fced8b61"
                 ],
                 "intervals": [
                     "chr22.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
                 ],
                 "versions": [
-                    "versions.yml:md5,4b4468e7d489cd525c0a04c2b6108f7d"
+                    "versions.yml:md5,cf114805fa4ead7ebdb7f875fced8b61"
                 ]
             }
         ],
-        "timestamp": "2026-03-22T09:55:07.690905883",
+        "timestamp": "2026-03-24T09:36:36.575625952",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.04.5"

--- a/modules/local/split_bed_by_chrom/tests/main.nf.test.snap
+++ b/modules/local/split_bed_by_chrom/tests/main.nf.test.snap
@@ -1,0 +1,25 @@
+{
+    "Should run without failures": {
+        "content": [
+            {
+                "0": [
+                    "chr22.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                ],
+                "1": [
+                    "versions.yml:md5,4b4468e7d489cd525c0a04c2b6108f7d"
+                ],
+                "intervals": [
+                    "chr22.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                ],
+                "versions": [
+                    "versions.yml:md5,4b4468e7d489cd525c0a04c2b6108f7d"
+                ]
+            }
+        ],
+        "timestamp": "2026-03-22T09:55:07.690905883",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.5"
+        }
+    }
+}

--- a/modules/local/split_fai_intervals/main.nf
+++ b/modules/local/split_fai_intervals/main.nf
@@ -24,7 +24,7 @@ process SPLIT_FAI_INTERVALS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        awk: \$(awk --version 2>&1 | awk 'NR==1{print \$3}' | tr -d ',')
+        awk: \$( { awk --version; awk -Wversion; } 2>&1 | grep -oE '[0-9]+[.][0-9]+[.][0-9]+' | head -1 )
     END_VERSIONS
     """
 

--- a/modules/local/split_fai_intervals/main.nf
+++ b/modules/local/split_fai_intervals/main.nf
@@ -20,11 +20,11 @@ process SPLIT_FAI_INTERVALS {
     script:
     """
     # Create one BED file per standard chromosome (handles both GRCh37 and GRCh38 naming)
-    awk 'BEGIN{OFS="\\t"} \$1 ~ /^(chr[0-9]+|chr[XYM]|chrMT|[0-9]+|X|Y|MT?)$/ {print \$1, 0, \$2 > \$1".bed"}' ${fai}
+    awk 'BEGIN{OFS="\\t"} \$1 ~ "^(chr[0-9]+|chr[XYM]|chrMT|[0-9]+|X|Y|MT?)\$" {print \$1, 0, \$2 > \$1".bed"}' ${fai}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        awk: \$(awk --version 2>&1 | head -1 | sed 's/[^0-9.]//g; s/^\\.//; s/\\.$//; s/\\.\\.*/./g')
+        awk: \$(awk --version 2>&1 | awk 'NR==1{print \$3}' | tr -d ',')
     END_VERSIONS
     """
 

--- a/modules/local/split_fai_intervals/main.nf
+++ b/modules/local/split_fai_intervals/main.nf
@@ -1,0 +1,40 @@
+process SPLIT_FAI_INTERVALS {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "conda-forge::gawk=5.3.0"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ubuntu:22.04' :
+        'nf-core/ubuntu:22.04' }"
+
+    input:
+    tuple val(meta), path(fai)
+
+    output:
+    path "*.bed",        emit: intervals
+    path "versions.yml", emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    """
+    # Create one BED file per standard chromosome (handles both GRCh37 and GRCh38 naming)
+    awk 'BEGIN{OFS="\\t"} \$1 ~ /^(chr[0-9]+|chr[XYM]|chrMT|[0-9]+|X|Y|MT?)$/ {print \$1, 0, \$2 > \$1".bed"}' ${fai}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        awk: \$(awk --version 2>&1 | head -1 | sed 's/[^0-9.]//g; s/^\\.//; s/\\.$//; s/\\.\\.*/./g')
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch chr1.bed
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        awk: 5.3.0
+    END_VERSIONS
+    """
+}

--- a/modules/local/split_fai_intervals/tests/main.nf.test
+++ b/modules/local/split_fai_intervals/tests/main.nf.test
@@ -1,0 +1,33 @@
+nextflow_process {
+
+    name "Test Process SPLIT_FAI_INTERVALS"
+    script "../main.nf"
+    process "SPLIT_FAI_INTERVALS"
+    tag "modules_local"
+    tag "modules"
+    tag "split_fai_intervals"
+
+    test("Should run without failures") {
+
+        when {
+            params {
+                modules_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(process.out).match()
+        }
+
+    }
+
+}

--- a/modules/local/split_fai_intervals/tests/main.nf.test.snap
+++ b/modules/local/split_fai_intervals/tests/main.nf.test.snap
@@ -1,0 +1,25 @@
+{
+    "Should run without failures": {
+        "content": [
+            {
+                "0": [
+                    "chr22.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                ],
+                "1": [
+                    "versions.yml:md5,6f8c48c08ec16a049629802f5b37c8db"
+                ],
+                "intervals": [
+                    "chr22.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                ],
+                "versions": [
+                    "versions.yml:md5,6f8c48c08ec16a049629802f5b37c8db"
+                ]
+            }
+        ],
+        "timestamp": "2026-03-22T09:54:07.758490358",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.5"
+        }
+    }
+}

--- a/modules/local/split_fai_intervals/tests/main.nf.test.snap
+++ b/modules/local/split_fai_intervals/tests/main.nf.test.snap
@@ -6,17 +6,17 @@
                     "chr22.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
                 ],
                 "1": [
-                    "versions.yml:md5,6f8c48c08ec16a049629802f5b37c8db"
+                    "versions.yml:md5,e61192cb13654412169c1e5438e064fd"
                 ],
                 "intervals": [
                     "chr22.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
                 ],
                 "versions": [
-                    "versions.yml:md5,6f8c48c08ec16a049629802f5b37c8db"
+                    "versions.yml:md5,e61192cb13654412169c1e5438e064fd"
                 ]
             }
         ],
-        "timestamp": "2026-03-22T09:54:07.758490358",
+        "timestamp": "2026-03-24T09:37:15.21104068",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.04.5"

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,6 +50,8 @@ params {
     skip_variant_calling         = false
     variant_caller               = 'bcftools'
     bcftools_caller_mode         = 'multiallelic'
+    ase_max_depth                = 1000
+    ase_intervals                = null
     skip_build_tracks            = false
     skip_stringtie               = false
     skip_drop_ae                 = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -319,6 +319,12 @@
                     "description": "BED file of regions to restrict GATK4 ASEReadCounter to (e.g. exons). When provided, the BED is split by chromosome and each job runs on one chromosome's regions in parallel.",
                     "fa_icon": "fas fa-sliders-h"
                 },
+                "ase_max_depth": {
+                    "type": "integer",
+                    "default": 1000,
+                    "description": "Maximum read depth per locus for GATK4 ASEReadCounter (--max-depth-per-sample). Lower values reduce memory usage on high-coverage regions.",
+                    "fa_icon": "fas fa-sliders-h"
+                },
                 "skip_variant_calling": {
                     "type": "boolean",
                     "default": false,

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -311,6 +311,14 @@
                     "enum": ["consensus", "multiallelic"],
                     "help_text": "Bcftools call can eitherbe run in multiallelic mode or in consensus mode. In consensus mode a p-value threshold of 0.01 is applied."
                 },
+                "ase_intervals": {
+                    "type": "string",
+                    "format": "file-path",
+                    "exists": true,
+                    "pattern": "^\\S+\\.bed$",
+                    "description": "BED file of regions to restrict GATK4 ASEReadCounter to (e.g. exons). When provided, the BED is split by chromosome and each job runs on one chromosome's regions in parallel.",
+                    "fa_icon": "fas fa-sliders-h"
+                },
                 "skip_variant_calling": {
                     "type": "boolean",
                     "default": false,

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -322,7 +322,7 @@
                 "ase_max_depth": {
                     "type": "integer",
                     "default": 1000,
-                    "description": "Maximum read depth per locus for GATK4 ASEReadCounter (--max-depth-per-sample). Lower values reduce memory usage on high-coverage regions.",
+                    "description": "Maximum read depth per locus for GATK4 ASEReadCounter (--max-depth-per-sample). Lower values reduce memory usage on high-coverage regions. Set to 0 to disable the cap (GATK default).",
                     "fa_icon": "fas fa-sliders-h"
                 },
                 "skip_variant_calling": {

--- a/nf-test.config
+++ b/nf-test.config
@@ -26,8 +26,8 @@ config {
 
     // Include plugins
     plugins {
-    //    load "nft-bam@0.6.0"
-    //    load "nft-utils@0.0.3"
-    //    load "nft-vcf@1.0.7"
+        load "nft-bam@0.6.0"
+        load "nft-utils@0.0.3"
+        load "nft-vcf@1.0.7"
     }
 }

--- a/nf-test.config
+++ b/nf-test.config
@@ -26,8 +26,8 @@ config {
 
     // Include plugins
     plugins {
-        load "nft-bam@0.6.0"
-        load "nft-utils@0.0.3"
-        load "nft-vcf@1.0.7"
+    //    load "nft-bam@0.6.0"
+    //    load "nft-utils@0.0.3"
+    //    load "nft-vcf@1.0.7"
     }
 }

--- a/subworkflows/local/allele_specific_calling/main.nf
+++ b/subworkflows/local/allele_specific_calling/main.nf
@@ -25,7 +25,7 @@ workflow ALLELE_SPECIFIC_CALLING {
     ch_dict            // channel: [mandatory] [ val(meta), path(dict) ]
     ch_case_info       // channel: [mandatory] [ val(case_info) ]
     ch_ase_intervals   // channel: [optional]  [ val(meta), path(bed) ] or empty channel
-    use_intervals  // boolean: true if ase_intervals param is provided
+    use_intervals      // boolean: true if ase_intervals param is provided
 
     main:
     ch_versions = Channel.empty()
@@ -83,11 +83,8 @@ workflow ALLELE_SPECIFIC_CALLING {
 
     // Gather: group per-interval CSVs back by original sample ID, then merge into one
     ch_ase_csvs = GATK4_ASEREADCOUNTER.out.csv
-        .map { meta, csv -> [meta.id, meta, csv] }
+        .map { meta, csv -> [meta - meta.subMap('interval'), csv] }
         .groupTuple()
-        .map { id, metas, csvs ->
-            [metas[0].findAll { k, v -> k != 'interval' }, csvs]
-        }
 
     MERGE_ASE_CSVS(ch_ase_csvs)
 

--- a/subworkflows/local/allele_specific_calling/main.nf
+++ b/subworkflows/local/allele_specific_calling/main.nf
@@ -25,6 +25,7 @@ workflow ALLELE_SPECIFIC_CALLING {
     ch_dict            // channel: [mandatory] [ val(meta), path(dict) ]
     ch_case_info       // channel: [mandatory] [ val(case_info) ]
     ch_ase_intervals   // channel: [optional]  [ val(meta), path(bed) ] or empty channel
+    use_intervals  // boolean: true if ase_intervals param is provided
 
     main:
     ch_versions = Channel.empty()
@@ -50,7 +51,7 @@ workflow ALLELE_SPECIFIC_CALLING {
     // If ase_intervals is provided: split that BED by chromosome — each job sees only
     // exonic variants on one chromosome, reducing memory and runtime per job.
     // Otherwise: derive whole-chromosome BEDs from the FAI as fallback.
-    if (params.ase_intervals) {
+    if (use_intervals) {
         SPLIT_BED_BY_CHROM(ch_ase_intervals)
         ch_interval_files = SPLIT_BED_BY_CHROM.out.intervals.flatten()
         ch_versions = ch_versions.mix( SPLIT_BED_BY_CHROM.out.versions )

--- a/subworkflows/local/allele_specific_calling/main.nf
+++ b/subworkflows/local/allele_specific_calling/main.nf
@@ -11,6 +11,8 @@ include { RENAME_FILES                         } from '../../../modules/local/re
 include { TABIX_TABIX                          } from '../../../modules/nf-core/tabix/tabix/main'
 include { BCFTOOLS_NORM as SPLIT_MULTIALLELICS } from '../../../modules/nf-core/bcftools/norm/main'
 include { BCFTOOLS_NORM as REMOVE_DUPLICATES   } from '../../../modules/nf-core/bcftools/norm/main'
+include { SPLIT_FAI_INTERVALS                  } from '../../../modules/local/split_fai_intervals/main'
+include { MERGE_ASE_CSVS                       } from '../../../modules/local/merge_ase_csvs/main'
 
 
 workflow ALLELE_SPECIFIC_CALLING {
@@ -41,16 +43,45 @@ workflow ALLELE_SPECIFIC_CALLING {
 
     ch_vcf_tbi_sample = BCFTOOLS_VIEW.out.vcf.join(BCFTOOLS_VIEW.out.tbi)
     ch_bam_bai_vcf_tbi = ch_bam_bai.join(ch_vcf_tbi_sample)
+
+    // Create per-chromosome interval BED files from FAI (run once on reference)
+    SPLIT_FAI_INTERVALS(ch_fai)
+
+    // Flatten list of BED files into individual channel items (one per chromosome)
+    ch_intervals = SPLIT_FAI_INTERVALS.out.intervals.flatten()
+
+    // Scatter: combine each sample with each interval → one job per sample per chromosome
+    ch_scattered = ch_bam_bai_vcf_tbi
+        .combine(ch_intervals)
+        .map { meta, bam, bai, vcf, tbi, interval ->
+            def new_meta = meta + [interval: interval.baseName]
+            [[new_meta, bam, bai, vcf, tbi], interval]
+        }
+        .multiMap { bam_vcf_input, interval ->
+            bam_vcf:   bam_vcf_input
+            intervals: interval
+        }
+
     GATK4_ASEREADCOUNTER(
-        ch_bam_bai_vcf_tbi,
+        ch_scattered.bam_vcf,
         ch_fasta,
         ch_fai,
         ch_dict,
-        []
+        ch_scattered.intervals
     )
 
+    // Gather: group per-interval CSVs back by original sample ID, then merge
+    ch_ase_csvs = GATK4_ASEREADCOUNTER.out.csv
+        .map { meta, csv -> [meta.id, meta, csv] }
+        .groupTuple()
+        .map { id, metas, csvs ->
+            [metas[0].findAll { k, v -> k != 'interval' }, csvs]
+        }
+
+    MERGE_ASE_CSVS(ch_ase_csvs)
+
     BOOTSTRAPANN(
-        ch_ind_vcf_tbi.join(GATK4_ASEREADCOUNTER.out.csv),
+        ch_ind_vcf_tbi.join(MERGE_ASE_CSVS.out.csv),
     )
 
     TABIX_BGZIPTABIX(BOOTSTRAPANN.out.vcf)
@@ -102,7 +133,9 @@ workflow ALLELE_SPECIFIC_CALLING {
 
     ch_versions = ch_versions.mix( BCFTOOLS_NORM.out.versions.first() )
     ch_versions = ch_versions.mix( BCFTOOLS_VIEW.out.versions.first() )
+    ch_versions = ch_versions.mix( SPLIT_FAI_INTERVALS.out.versions )
     ch_versions = ch_versions.mix( GATK4_ASEREADCOUNTER.out.versions.first() )
+    ch_versions = ch_versions.mix( MERGE_ASE_CSVS.out.versions.first() )
     ch_versions = ch_versions.mix( BOOTSTRAPANN.out.versions.first() )
     ch_versions = ch_versions.mix( TABIX_BGZIPTABIX.out.versions.first() )
     ch_versions = ch_versions.mix( BCFTOOLS_MERGE.out.versions.first() )

--- a/subworkflows/local/allele_specific_calling/main.nf
+++ b/subworkflows/local/allele_specific_calling/main.nf
@@ -91,7 +91,10 @@ workflow ALLELE_SPECIFIC_CALLING {
     MERGE_ASE_CSVS(ch_ase_csvs)
 
     BOOTSTRAPANN(
-        ch_ind_vcf_tbi.join(MERGE_ASE_CSVS.out.csv),
+        ch_ind_vcf_tbi
+            .map { meta, vcf, tbi -> [meta.id, meta, vcf, tbi] }
+            .join(MERGE_ASE_CSVS.out.csv.map { meta, csv -> [meta.id, csv] })
+            .map { id, meta, vcf, tbi, csv -> [meta, vcf, tbi, csv] }
     )
 
     TABIX_BGZIPTABIX(BOOTSTRAPANN.out.vcf)

--- a/subworkflows/local/allele_specific_calling/main.nf
+++ b/subworkflows/local/allele_specific_calling/main.nf
@@ -12,6 +12,7 @@ include { TABIX_TABIX                          } from '../../../modules/nf-core/
 include { BCFTOOLS_NORM as SPLIT_MULTIALLELICS } from '../../../modules/nf-core/bcftools/norm/main'
 include { BCFTOOLS_NORM as REMOVE_DUPLICATES   } from '../../../modules/nf-core/bcftools/norm/main'
 include { SPLIT_FAI_INTERVALS                  } from '../../../modules/local/split_fai_intervals/main'
+include { SPLIT_BED_BY_CHROM                   } from '../../../modules/local/split_bed_by_chrom/main'
 include { MERGE_ASE_CSVS                       } from '../../../modules/local/merge_ase_csvs/main'
 
 
@@ -23,6 +24,7 @@ workflow ALLELE_SPECIFIC_CALLING {
     ch_fai             // channel: [mandatory] [ val(meta), path(fai) ]
     ch_dict            // channel: [mandatory] [ val(meta), path(dict) ]
     ch_case_info       // channel: [mandatory] [ val(case_info) ]
+    ch_ase_intervals   // channel: [optional]  [ val(meta), path(bed) ] or empty channel
 
     main:
     ch_versions = Channel.empty()
@@ -44,15 +46,23 @@ workflow ALLELE_SPECIFIC_CALLING {
     ch_vcf_tbi_sample = BCFTOOLS_VIEW.out.vcf.join(BCFTOOLS_VIEW.out.tbi)
     ch_bam_bai_vcf_tbi = ch_bam_bai.join(ch_vcf_tbi_sample)
 
-    // Create per-chromosome interval BED files from FAI (run once on reference)
-    SPLIT_FAI_INTERVALS(ch_fai)
-
-    // Flatten list of BED files into individual channel items (one per chromosome)
-    ch_intervals = SPLIT_FAI_INTERVALS.out.intervals.flatten()
+    // Create per-chromosome interval BED files for scatter-gather parallelisation.
+    // If ase_intervals is provided: split that BED by chromosome — each job sees only
+    // exonic variants on one chromosome, reducing memory and runtime per job.
+    // Otherwise: derive whole-chromosome BEDs from the FAI as fallback.
+    if (params.ase_intervals) {
+        SPLIT_BED_BY_CHROM(ch_ase_intervals)
+        ch_interval_files = SPLIT_BED_BY_CHROM.out.intervals.flatten()
+        ch_versions = ch_versions.mix( SPLIT_BED_BY_CHROM.out.versions )
+    } else {
+        SPLIT_FAI_INTERVALS(ch_fai)
+        ch_interval_files = SPLIT_FAI_INTERVALS.out.intervals.flatten()
+        ch_versions = ch_versions.mix( SPLIT_FAI_INTERVALS.out.versions )
+    }
 
     // Scatter: combine each sample with each interval → one job per sample per chromosome
     ch_scattered = ch_bam_bai_vcf_tbi
-        .combine(ch_intervals)
+        .combine(ch_interval_files)
         .map { meta, bam, bai, vcf, tbi, interval ->
             def new_meta = meta + [interval: interval.baseName]
             [[new_meta, bam, bai, vcf, tbi], interval]
@@ -70,7 +80,7 @@ workflow ALLELE_SPECIFIC_CALLING {
         ch_scattered.intervals
     )
 
-    // Gather: group per-interval CSVs back by original sample ID, then merge
+    // Gather: group per-interval CSVs back by original sample ID, then merge into one
     ch_ase_csvs = GATK4_ASEREADCOUNTER.out.csv
         .map { meta, csv -> [meta.id, meta, csv] }
         .groupTuple()
@@ -133,7 +143,6 @@ workflow ALLELE_SPECIFIC_CALLING {
 
     ch_versions = ch_versions.mix( BCFTOOLS_NORM.out.versions.first() )
     ch_versions = ch_versions.mix( BCFTOOLS_VIEW.out.versions.first() )
-    ch_versions = ch_versions.mix( SPLIT_FAI_INTERVALS.out.versions )
     ch_versions = ch_versions.mix( GATK4_ASEREADCOUNTER.out.versions.first() )
     ch_versions = ch_versions.mix( MERGE_ASE_CSVS.out.versions.first() )
     ch_versions = ch_versions.mix( BOOTSTRAPANN.out.versions.first() )

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -93,7 +93,7 @@
                     "sj2bed": "v1.0"
                 },
                 "MERGE_ASE_CSVS": {
-                    "awk": "5.3.0"
+                    "awk": "1.3.4"
                 },
                 "PICARD_COLLECTINSERTSIZEMETRICS": {
                     "picard": "3.3.0"
@@ -132,7 +132,7 @@
                     "samtools": "1.22.1"
                 },
                 "SPLIT_FAI_INTERVALS": {
-                    "awk": "5.3.0"
+                    "awk": "1.3.4"
                 },
                 "SPLIT_MULTIALLELICS": {
                     "bcftools": 1.22

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -131,6 +131,9 @@
                 "SAMTOOLS_VIEW": {
                     "samtools": "1.22.1"
                 },
+                "SPLIT_FAI_INTERVALS": {
+                    "awk": "5.3.0"
+                },
                 "SPLIT_MULTIALLELICS": {
                     "bcftools": 1.22
                 },

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test": {
         "content": [
-            89,
+            93,
             {
                 "ADD_FOUND_IN_TAG": {
                     "bcftools": 1.2,
@@ -91,6 +91,9 @@
                 },
                 "JUNCTION_TRACK": {
                     "sj2bed": "v1.0"
+                },
+                "MERGE_ASE_CSVS": {
+                    "awk": "5.3.0"
                 },
                 "PICARD_COLLECTINSERTSIZEMETRICS": {
                     "picard": "3.3.0"

--- a/workflows/tomte.nf
+++ b/workflows/tomte.nf
@@ -230,13 +230,18 @@ workflow TOMTE {
         ch_vcf_tbi = CALL_VARIANTS.out.vcf_tbi
         ch_versions = ch_versions.mix(CALL_VARIANTS.out.versions)
 
+        ch_ase_intervals = params.ase_intervals
+            ? Channel.fromPath(params.ase_intervals).map { f -> [[id: 'ase_intervals'], f] }
+            : Channel.empty()
+
         ALLELE_SPECIFIC_CALLING(
             ch_vcf_tbi,
             ch_alignment.bam_bai,
             ch_references.fasta,
             ch_references.fai,
             ch_references.sequence_dict,
-            ch_case_info
+            ch_case_info,
+            ch_ase_intervals
         )
         ch_versions = ch_versions.mix(ALLELE_SPECIFIC_CALLING.out.versions)
 

--- a/workflows/tomte.nf
+++ b/workflows/tomte.nf
@@ -241,7 +241,8 @@ workflow TOMTE {
             ch_references.fai,
             ch_references.sequence_dict,
             ch_case_info,
-            ch_ase_intervals
+            ch_ase_intervals,
+            params.ase_intervals ? true : false
         )
         ch_versions = ch_versions.mix(ALLELE_SPECIFIC_CALLING.out.versions)
 

--- a/workflows/tomte.nf
+++ b/workflows/tomte.nf
@@ -99,6 +99,8 @@ workflow TOMTE {
                                                                         : Channel.empty()
     ch_hb_genes                   = params.hb_genes                     ? Channel.fromPath(params.hb_genes).collect()
                                                                         : Channel.empty()
+    ch_ase_intervals              = params.ase_intervals                ? Channel.fromPath(params.ase_intervals).map { it -> [[id:it.getSimpleName()], it] }.collect()
+                                                                        : Channel.empty()
 
     // Read and store paths in the vep_plugin_files file
     ch_vep_extra_files_unsplit.splitCsv(header: true)
@@ -229,10 +231,6 @@ workflow TOMTE {
         )
         ch_vcf_tbi = CALL_VARIANTS.out.vcf_tbi
         ch_versions = ch_versions.mix(CALL_VARIANTS.out.versions)
-
-        ch_ase_intervals = params.ase_intervals
-            ? Channel.fromPath(params.ase_intervals).map { f -> [[id: 'ase_intervals'], f] }
-            : Channel.empty()
 
         ALLELE_SPECIFIC_CALLING(
             ch_vcf_tbi,


### PR DESCRIPTION
<!--
# genomic-medicine-sweden/tomte pull request

Many thanks for contributing to genomic-medicine-sweden/tomte!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/tomte/tree/master/.github/CONTRIBUTING.md)



-->
  What: ASEReadCounter now runs per chromosome in parallel (scatter-gather) instead of on the whole genome in a single job. Results are merged back into one CSV per sample using a new
  merge_ase_csvs module.

  Why: For deeply sequenced samples (e.g. whole blood with high globin expression), the single-job approach caused excessive memory usage and long runtimes. Parallelising per
  chromosome reduces peak memory per job and significantly improves overall runtime.

  New local modules:
  - split_fai_intervals — derives per-chromosome BED files from the genome FAI
  - split_bed_by_chrom — splits a user-provided BED file by chromosome
  - merge_ase_csvs — merges per-chromosome ASEReadCounter CSV outputs into one file per sample

  New parameters

  - --ase_intervals — optional BED file (e.g. exons) to restrict ASEReadCounter to specific regions. If not provided, ASEReadCounter runs over whole chromosomes. Providing an exon BED
  reduces runtime further.
  - --ase_max_depth — maximum read depth per sample passed to GATK4 ASEReadCounter (--max-depth-per-sample). Default: 1000. Prevents excessive memory usage in samples with very high
  read depth at individual positions (e.g. globin genes in blood samples).

  Bug fix

  Fixed a channel join issue in ALLELE_SPECIFIC_CALLING where BOOTSTRAPANN was joined on the full meta object instead of meta.id, causing an empty channel after scatter-gather.

## PR checklist

- [ x] This comment contains a description of changes (with reason).
- [ x] If you've fixed a bug or added code that should be tested, add tests!
(https://github.com/genomic-medicine-sweden/tomte/tree/master/.github/CONTRIBUTING.md)
- [x ] Make sure your code lints (`nf-core pipelines lint`).
- [ x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x ] Usage Documentation in `docs/usage.md` is updated.
- [ x] `CHANGELOG.md` is updated.

