### PR TITLE
Fix uncachable GET_CHROM_SIZES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - Fixed naming of files in DROP_FILTER_RESULTS when running with `-stub` flag. [#291](https://github.com/genomic-medicine-sweden/tomte/pull/291)
-- Fixed processes not being able to be cached properly on resume [#294](https://github.com/genomic-medicine-sweden/tomte/pull/291)
+- Fixed processes not being able to be cached properly on resume [#294](https://github.com/genomic-medicine-sweden/tomte/pull/294)
 
 ### `Parameters`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#291](https://github.com/genomic-medicine-sweden/tomte/pull/291): Fixed naming of files in DROP_FILTER_RESULTS when running with `-stub` flag.
+- Fixed naming of files in DROP_FILTER_RESULTS when running with `-stub` flag. [#291](https://github.com/genomic-medicine-sweden/tomte/pull/291)
+- Fixed processes not being able to be cached properly on resume [#294](https://github.com/genomic-medicine-sweden/tomte/pull/291)
 
 ### `Parameters`
 

--- a/conf/modules/prepare_references.config
+++ b/conf/modules/prepare_references.config
@@ -68,7 +68,13 @@ process {
 
     withName: '.*PREPARE_REFERENCES:GET_CHROM_SIZES' {
         ext.args = '-v OFS="\\t" \'{print \$1,\$2}\''
-        ext.suffix = 'sizes'
+        ext.suffix = 'fa.sizes'
+        publishDir = [
+            path: { "${params.outdir}/references" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+            enabled: params.save_reference
+        ]
     }
 
     withName: '.*PREPARE_REFERENCES:UNTAR_STAR_INDEX' {

--- a/conf/modules/prepare_references.config
+++ b/conf/modules/prepare_references.config
@@ -67,12 +67,8 @@ process {
     }
 
     withName: '.*PREPARE_REFERENCES:GET_CHROM_SIZES' {
-        publishDir = [
-            path: { "${params.outdir}/references" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
-            enabled: params.save_reference
-        ]
+        ext.args = '-v OFS="\\t" \'{print \$1,\$2}\''
+        ext.suffix = 'sizes'
     }
 
     withName: '.*PREPARE_REFERENCES:UNTAR_STAR_INDEX' {

--- a/subworkflows/local/prepare_references/main.nf
+++ b/subworkflows/local/prepare_references/main.nf
@@ -8,7 +8,7 @@ include { GATK4_CREATESEQUENCEDICTIONARY as BUILD_DICT } from '../../../modules/
 include { GUNZIP as GUNZIP_GTF                         } from '../../../modules/nf-core/gunzip'
 include { GET_RRNA_TRANSCRIPTS                         } from '../../../modules/local/get_rrna_transcripts'
 include { UCSC_GTFTOGENEPRED                           } from '../../../modules/nf-core/ucsc/gtftogenepred'
-include { SAMTOOLS_FAIDX as GET_CHROM_SIZES            } from '../../../modules/nf-core/samtools/faidx'
+include { GAWK as GET_CHROM_SIZES                      } from '../../../modules/nf-core/gawk'
 include { GUNZIP as GUNZIP_TRFASTA                     } from '../../../modules/nf-core/gunzip'
 include { GFFREAD                                      } from '../../../modules/nf-core/gffread'
 include { SAMTOOLS_FAIDX as SAMTOOLS_FAIDX_GENOME      } from '../../../modules/nf-core/samtools/faidx'
@@ -42,7 +42,7 @@ workflow PREPARE_REFERENCES {
 
 
     main:
-    ch_versions = Channel.empty()
+    ch_versions = channel.empty()
 
     // Gunzip fasta if necessary
     if ( gunzip_fasta ) {
@@ -54,7 +54,11 @@ workflow PREPARE_REFERENCES {
     }
     // If no genome indices, create it
     if ( build_fai ) {
-        SAMTOOLS_FAIDX_GENOME( ch_fasta_final,[[],[]], [] )
+        SAMTOOLS_FAIDX_GENOME(
+            ch_fasta_final,
+            [[],[]],
+            false,
+        )
         ch_fai = SAMTOOLS_FAIDX_GENOME.out.fai.collect()
         ch_versions = ch_versions.mix( SAMTOOLS_FAIDX_GENOME.out.versions )
     } else {
@@ -70,12 +74,13 @@ workflow PREPARE_REFERENCES {
         ch_dict_final = ch_sequence_dict_input.collect()
     }
 
-    // Get chrom sizes
+    // If we wanted to use SAMTOOLS_FAIDX to get the sizes, we would always have to make a fai
+    // This is because in the current state of this module, if you input a fai, it always gets overwritten and nextflow therefore can't cache it.
     GET_CHROM_SIZES(
-        ch_fasta_final,
         ch_fai,
-        true
-        )
+        [],
+        false
+    )
 
     // Gunzip gtf if necessary
     if ( gunzip_gtf ) {
@@ -161,7 +166,7 @@ workflow PREPARE_REFERENCES {
     ch_versions = ch_versions.mix(BEDTOINTERVALLIST.out.versions)
 
     emit:
-    chrom_sizes   = GET_CHROM_SIZES.out.sizes
+    chrom_sizes   = GET_CHROM_SIZES.out.output
         .map{ _meta, sizes -> sizes }.collect()            // channel: [ path(sizes) ]
     fasta         = ch_fasta_final                         // channel: [ val(meta), path(fasta) ]
     fai           = ch_fai                                 // channel: [ val(meta), path(fai) ]

--- a/subworkflows/local/prepare_references/tests/prepare_references.nf.test.snap
+++ b/subworkflows/local/prepare_references/tests/prepare_references.nf.test.snap
@@ -5,13 +5,13 @@
                 "versions.yml:md5,0167a41d391aeaacd671cafbc33b3eb3",
                 "versions.yml:md5,40ceea3a3e5ebf53fcb72999eb60aab6",
                 "versions.yml:md5,7479477c0c4b6eb043c58bc40ee41198",
-                "versions.yml:md5,808f8c4e5b5c2f18317d600c8721b6ec",
+                "versions.yml:md5,879e4ca2fb48edf399f7a06f7862c576",
                 "versions.yml:md5,d953fa5aa699773c604a83da00b38653",
                 "versions.yml:md5,e7c1df4658cbbcecf6bc63b0ba105049"
             ],
             [
                 [
-                    "grch37_chr21.fa.sizes:md5,ffd90da532db7928daa1591d45dc26c4"
+                    "fasta.sizes:md5,ffd90da532db7928daa1591d45dc26c4"
                 ]
             ],
             [
@@ -286,11 +286,11 @@
                 ]
             ]
         ],
+        "timestamp": "2026-04-01T09:30:57.456875996",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.5"
-        },
-        "timestamp": "2025-09-19T11:40:34.48563076"
+            "nf-test": "0.9.5",
+            "nextflow": "26.03.1"
+        }
     },
     "Providing compressed references": {
         "content": [
@@ -301,7 +301,7 @@
                 "versions.yml:md5,4c6282c3f2e41fd055713a78b4406a8b",
                 "versions.yml:md5,53ba80d1edc3452084e1ff487d1232ee",
                 "versions.yml:md5,7479477c0c4b6eb043c58bc40ee41198",
-                "versions.yml:md5,808f8c4e5b5c2f18317d600c8721b6ec",
+                "versions.yml:md5,879e4ca2fb48edf399f7a06f7862c576",
                 "versions.yml:md5,b079b3b18731275ef54c99647ad39c32",
                 "versions.yml:md5,b852853ecc4b28cfb496141f11f3bc22",
                 "versions.yml:md5,cfb207f0c717bce0b7d8da48210310b7",
@@ -310,7 +310,7 @@
             ],
             [
                 [
-                    "grch37_chr21.fa.sizes:md5,ffd90da532db7928daa1591d45dc26c4"
+                    "grch37_chr21.sizes:md5,ffd90da532db7928daa1591d45dc26c4"
                 ]
             ],
             [
@@ -585,10 +585,10 @@
                 ]
             ]
         ],
+        "timestamp": "2026-04-01T09:30:15.591085169",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.5"
-        },
-        "timestamp": "2025-09-19T11:39:51.573525051"
+            "nf-test": "0.9.5",
+            "nextflow": "26.03.1"
+        }
     }
 }

--- a/subworkflows/local/prepare_references/tests/prepare_references.nf.test.snap
+++ b/subworkflows/local/prepare_references/tests/prepare_references.nf.test.snap
@@ -11,7 +11,7 @@
             ],
             [
                 [
-                    "fasta.sizes:md5,ffd90da532db7928daa1591d45dc26c4"
+                    "fasta.fa.sizes:md5,ffd90da532db7928daa1591d45dc26c4"
                 ]
             ],
             [
@@ -286,7 +286,7 @@
                 ]
             ]
         ],
-        "timestamp": "2026-04-01T09:30:57.456875996",
+        "timestamp": "2026-04-01T13:20:38.397959005",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.03.1"
@@ -310,7 +310,7 @@
             ],
             [
                 [
-                    "grch37_chr21.sizes:md5,ffd90da532db7928daa1591d45dc26c4"
+                    "grch37_chr21.fa.sizes:md5,ffd90da532db7928daa1591d45dc26c4"
                 ]
             ],
             [
@@ -585,7 +585,7 @@
                 ]
             ]
         ],
-        "timestamp": "2026-04-01T09:30:15.591085169",
+        "timestamp": "2026-04-01T13:20:01.145862272",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.03.1"

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -72,7 +72,7 @@
                     "gawk": "5.3.0"
                 },
                 "GET_CHROM_SIZES": {
-                    "samtools": "1.22.1"
+                    "gawk": "5.3.0"
                 },
                 "GET_RRNA_TRANSCRIPTS": {
                     "get_rrna_transcripts": "v1.0"
@@ -341,6 +341,8 @@
                 "fastqc/ACC5963A2_id1_2_fastqc.zip",
                 "gawk",
                 "gawk/hgnc.tsv",
+                "get",
+                "get/grch37_chr21.sizes",
                 "junction",
                 "junction/ACC5963A2_junction.bed",
                 "multiqc",
@@ -432,7 +434,6 @@
                 "references/grch37_chr21.dict",
                 "references/grch37_chr21.fa",
                 "references/grch37_chr21.fa.fai",
-                "references/grch37_chr21.fa.sizes",
                 "references/grch37_chr21.gtf",
                 "references/grch37_chr21.refflat",
                 "references/rrna.bed",
@@ -504,12 +505,12 @@
                 "i_data.ctab:md5,a64ec517859ed296146a5497ec5cf645",
                 "t_data.ctab:md5,adea5cce0d453ca8108143842b21157c",
                 "hgnc.tsv:md5,bbf07f9733fbd7e4666f039b5c4be128",
+                "grch37_chr21.sizes:md5,ffd90da532db7928daa1591d45dc26c4",
                 "ACC5963A2_junction.bed:md5,7b66db28a4b006d798a96fbc81f345e5",
                 "GRCh37_gffread_output.fasta:md5,7dbf3195d06f480fa5b2421004580bdd",
                 "grch37_chr21.dict:md5,53d95c36db0422d29db02c8a8da56e43",
                 "grch37_chr21.fa:md5,e9ce36e75cd57d255ad64eb2ecca4dd0",
                 "grch37_chr21.fa.fai:md5,93c052a6e351d5db0d7a0156816f51fb",
-                "grch37_chr21.fa.sizes:md5,ffd90da532db7928daa1591d45dc26c4",
                 "grch37_chr21.gtf:md5,01924b6ce7016e41d5e2b22e478ca12f",
                 "grch37_chr21.refflat:md5,9c34a780a2505949c4c613dfc79f8d2d",
                 "rrna.bed:md5,1c99687a18201c904edc40fb03088787",
@@ -679,10 +680,10 @@
                 ]
             ]
         ],
+        "timestamp": "2026-04-01T09:41:16.417148123",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-11-12T15:06:36.55447099"
+            "nf-test": "0.9.5",
+            "nextflow": "26.03.1"
+        }
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -341,8 +341,6 @@
                 "fastqc/ACC5963A2_id1_2_fastqc.zip",
                 "gawk",
                 "gawk/hgnc.tsv",
-                "get",
-                "get/grch37_chr21.sizes",
                 "junction",
                 "junction/ACC5963A2_junction.bed",
                 "multiqc",
@@ -434,6 +432,7 @@
                 "references/grch37_chr21.dict",
                 "references/grch37_chr21.fa",
                 "references/grch37_chr21.fa.fai",
+                "references/grch37_chr21.fa.sizes",
                 "references/grch37_chr21.gtf",
                 "references/grch37_chr21.refflat",
                 "references/rrna.bed",
@@ -505,12 +504,12 @@
                 "i_data.ctab:md5,a64ec517859ed296146a5497ec5cf645",
                 "t_data.ctab:md5,adea5cce0d453ca8108143842b21157c",
                 "hgnc.tsv:md5,bbf07f9733fbd7e4666f039b5c4be128",
-                "grch37_chr21.sizes:md5,ffd90da532db7928daa1591d45dc26c4",
                 "ACC5963A2_junction.bed:md5,7b66db28a4b006d798a96fbc81f345e5",
                 "GRCh37_gffread_output.fasta:md5,7dbf3195d06f480fa5b2421004580bdd",
                 "grch37_chr21.dict:md5,53d95c36db0422d29db02c8a8da56e43",
                 "grch37_chr21.fa:md5,e9ce36e75cd57d255ad64eb2ecca4dd0",
                 "grch37_chr21.fa.fai:md5,93c052a6e351d5db0d7a0156816f51fb",
+                "grch37_chr21.fa.sizes:md5,ffd90da532db7928daa1591d45dc26c4",
                 "grch37_chr21.gtf:md5,01924b6ce7016e41d5e2b22e478ca12f",
                 "grch37_chr21.refflat:md5,9c34a780a2505949c4c613dfc79f8d2d",
                 "rrna.bed:md5,1c99687a18201c904edc40fb03088787",
@@ -680,7 +679,7 @@
                 ]
             ]
         ],
-        "timestamp": "2026-04-01T09:41:16.417148123",
+        "timestamp": "2026-04-01T13:50:13.466363393",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.03.1"

--- a/tests/skip_main.nf.test.snap
+++ b/tests/skip_main.nf.test.snap
@@ -32,7 +32,7 @@
                     "fastqc": "0.12.1"
                 },
                 "GET_CHROM_SIZES": {
-                    "samtools": "1.22.1"
+                    "gawk": "5.3.0"
                 },
                 "GET_RRNA_TRANSCRIPTS": {
                     "get_rrna_transcripts": "v1.0"
@@ -190,6 +190,8 @@
                 "fastqc/ACC5963A2_id1_1_fastqc.zip",
                 "fastqc/ACC5963A2_id1_2_fastqc.html",
                 "fastqc/ACC5963A2_id1_2_fastqc.zip",
+                "get",
+                "get/grch37_chr21.sizes",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/fastp-insert-size-plot.txt",
@@ -258,7 +260,6 @@
                 "references/grch37_chr21.dict",
                 "references/grch37_chr21.fa",
                 "references/grch37_chr21.fa.fai",
-                "references/grch37_chr21.fa.sizes",
                 "references/grch37_chr21.gtf",
                 "references/grch37_chr21.refflat",
                 "references/rrna.bed",
@@ -310,11 +311,11 @@
                 "ACC5963A2.SJ.out.tab:md5,dea5d6b61390b2e01699441ad0c56b05",
                 "ACC5963A2.Signal.Unique.str1.out.wig:md5,75d340d4376d489b0333e86b71cd6abc",
                 "ACC5963A2.Signal.UniqueMultiple.str1.out.wig:md5,cd24fce0ca9d2cde46af931c5afaa69d",
+                "grch37_chr21.sizes:md5,ffd90da532db7928daa1591d45dc26c4",
                 "GRCh37_gffread_output.fasta:md5,7dbf3195d06f480fa5b2421004580bdd",
                 "grch37_chr21.dict:md5,53d95c36db0422d29db02c8a8da56e43",
                 "grch37_chr21.fa:md5,e9ce36e75cd57d255ad64eb2ecca4dd0",
                 "grch37_chr21.fa.fai:md5,93c052a6e351d5db0d7a0156816f51fb",
-                "grch37_chr21.fa.sizes:md5,ffd90da532db7928daa1591d45dc26c4",
                 "grch37_chr21.gtf:md5,01924b6ce7016e41d5e2b22e478ca12f",
                 "grch37_chr21.refflat:md5,9c34a780a2505949c4c613dfc79f8d2d",
                 "rrna.bed:md5,1c99687a18201c904edc40fb03088787",
@@ -371,10 +372,10 @@
                 ]
             ]
         ],
+        "timestamp": "2026-04-01T09:46:24.954666299",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-11-12T15:11:03.220711668"
+            "nf-test": "0.9.5",
+            "nextflow": "26.03.1"
+        }
     }
 }

--- a/tests/skip_main.nf.test.snap
+++ b/tests/skip_main.nf.test.snap
@@ -190,8 +190,6 @@
                 "fastqc/ACC5963A2_id1_1_fastqc.zip",
                 "fastqc/ACC5963A2_id1_2_fastqc.html",
                 "fastqc/ACC5963A2_id1_2_fastqc.zip",
-                "get",
-                "get/grch37_chr21.sizes",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/fastp-insert-size-plot.txt",
@@ -260,6 +258,7 @@
                 "references/grch37_chr21.dict",
                 "references/grch37_chr21.fa",
                 "references/grch37_chr21.fa.fai",
+                "references/grch37_chr21.fa.sizes",
                 "references/grch37_chr21.gtf",
                 "references/grch37_chr21.refflat",
                 "references/rrna.bed",
@@ -311,11 +310,11 @@
                 "ACC5963A2.SJ.out.tab:md5,dea5d6b61390b2e01699441ad0c56b05",
                 "ACC5963A2.Signal.Unique.str1.out.wig:md5,75d340d4376d489b0333e86b71cd6abc",
                 "ACC5963A2.Signal.UniqueMultiple.str1.out.wig:md5,cd24fce0ca9d2cde46af931c5afaa69d",
-                "grch37_chr21.sizes:md5,ffd90da532db7928daa1591d45dc26c4",
                 "GRCh37_gffread_output.fasta:md5,7dbf3195d06f480fa5b2421004580bdd",
                 "grch37_chr21.dict:md5,53d95c36db0422d29db02c8a8da56e43",
                 "grch37_chr21.fa:md5,e9ce36e75cd57d255ad64eb2ecca4dd0",
                 "grch37_chr21.fa.fai:md5,93c052a6e351d5db0d7a0156816f51fb",
+                "grch37_chr21.fa.sizes:md5,ffd90da532db7928daa1591d45dc26c4",
                 "grch37_chr21.gtf:md5,01924b6ce7016e41d5e2b22e478ca12f",
                 "grch37_chr21.refflat:md5,9c34a780a2505949c4c613dfc79f8d2d",
                 "rrna.bed:md5,1c99687a18201c904edc40fb03088787",
@@ -372,7 +371,7 @@
                 ]
             ]
         ],
-        "timestamp": "2026-04-01T09:46:24.954666299",
+        "timestamp": "2026-04-01T13:55:57.356513887",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.03.1"


### PR DESCRIPTION
In the current state, `GET_CHROM_SIZES` was unable to cache on resume. This is because `SAMTOOLS_FAIDX` will always regenerate the index, (and therefore overwrite the input fai file), so it can't be cached. 

This could either be solved by always generating a fai, but this PR keeps the current logic by replacing the second samtools faidx (which creates the sizes file) with a gawk module.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/tomte/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
